### PR TITLE
Update lab_1.ipynb: Changing nltk punkt -> punkt_tab for nltk safety

### DIFF
--- a/labs/notebooks_2024/lab_1.ipynb
+++ b/labs/notebooks_2024/lab_1.ipynb
@@ -249,7 +249,7 @@
    ],
    "source": [
     "import nltk\n",
-    "nltk.download('punkt')\n",
+    "nltk.download('punkt_tab')\n",
     "\n",
     "text = \"Time flies like an arrow.\""
    ]


### PR DESCRIPTION
related issue: https://github.com/nltk/nltk/issues/3293

It is said that the "punkt" package consists in unsafe pickles, so it is deprecated and not used in NLTK 3.8.2. It is replaced by "punkt_tab".