### PR TITLE
Update SLP3 reading links for August 2026 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,42 +27,42 @@ Materials from this interactive book are used throughout the Natural Language Pr
    </tr>
    <tr>
       <td>38</td>
-      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/17.pdf'>Chapter 17</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/19.pdf'>Chapter 19</a> </td>
+      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/18.pdf'>Chapter 18</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/20.pdf'>Chapter 20</a> </td>
       <td>29. Sep. 2026:<br> Sequence Labelling (<a href='chapters/sequence_labeling_slides.ipynb'>slides</a>)<br> Parsing (<a href='chapters/dependency_parsing_slides_active.ipynb'>slides</a>)<br> </td>
       <td>2. &amp; 5. Oct. 2026:<br> Sequence labelling and beam search<br> Project help<br> </td>
       <td><a href='labs/notebooks_2025/lab_3.ipynb'>lab 3</a></td>
    </tr>
    <tr>
       <td>39</td>
-      <td><a href='https://web.stanford.edu/~jurafsky/slp3/13.pdf'>Chapter 13</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/7.pdf'>Chapter 7</a> </td>
+      <td><a href='https://web.stanford.edu/~jurafsky/slp3/14.pdf'>Chapter 14</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/7.pdf'>Chapter 7</a> </td>
       <td>15. Sep. 2026:<br> Recurrent Neural Networks (<a href='chapters/rnn_slides_ucph.ipynb'>slides</a>)<br> Neural Language Models (<a href='chapters/dl-representations_contextual.ipynb'>slides</a>)<br> </td>
       <td>18. &amp; 21. Sep. 2026:<br> Error analysis and explainability<br> Project help<br> </td>
       <td><a href='labs/notebooks_2025/lab_4.ipynb'>lab 4</a></td>
    </tr>
    <tr>
       <td>40</td>
-      <td><a href='https://web.stanford.edu/~jurafsky/slp3/8.pdf'>Chapter 8</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/10.pdf'>Chapter 10</a></td>
+      <td><a href='https://web.stanford.edu/~jurafsky/slp3/7.pdf'>Chapter 7</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/9.pdf'>Chapter 9</a></td>
       <td>22. Sep. 2026:<br> Attention (<a href='chapters/attention_slides2.ipynb'>slides</a>)<br> Transformers (<a href='chapters/dl-representations_contextual_transformers.ipynb'>slides</a>)<br> </td>
       <td>25. &amp; 28. Sep. 2026:<br> Language Models with <a href='https://huggingface.co/course/chapter1'>Transformers</a> and RNNs<br> Project help<br> </td>
       <td><a href='labs/notebooks_2025/lab_5.ipynb'>lab 5</a></td>
    </tr>
    <tr>
       <td>41</td>
-      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/20.pdf'>Chapter 20</a><br><a href="https://aclanthology.org/2020.tacl-1.30.pdf">Clark et al., 2020</a> </td>
+      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/21.pdf'>Chapter 21</a><br><a href="https://aclanthology.org/2020.tacl-1.30.pdf">Clark et al., 2020</a> </td>
       <td>6. Oct. 2026:<br> Information Extraction (<a href='chapters/information_extraction_slides.ipynb'>slides</a>)<br> Question Answering (<a href='chapters/question_answering_slides.ipynb'>slides</a>)<br> </td>
       <td>9. &amp; 19. Oct. 2026:<br> In-depth look at Transformers and Multilingual QA<br> Project help<br> </td>
       <td><a href='labs/notebooks_2025/lab_6.ipynb'>lab 6</a></td>
    </tr>
    <tr>
       <td>43</td>
-      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/12.pdf'>Chapter 12</a><br><a href="https://aclanthology.org/2022.acl-long.482.pdf">Hershcovich et al., 2022</a> </td>
+      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/13.pdf'>Chapter 13</a><br><a href="https://aclanthology.org/2022.acl-long.482.pdf">Hershcovich et al., 2022</a> </td>
       <td>20. Oct. 2026:<br> Machine Translation (<a href='chapters/nmt_slides_active.ipynb'>slides</a>)<br> Multilingual and Multicultural NLP (<a href='chapters/xling_transfer_learning_slides.ipynb'>slides</a>)<br> </td>
       <td>23. &amp; 26. Oct. 2026: Project help.</td>
       <td></td>
    </tr>
    <tr>
       <td>44</td>
-      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/9.pdf'>Chapter 9 up to end of 9.3</a><br> <a href='https://arxiv.org/abs/2508.16982'> Chalkidis, 2026</a></td>
+      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/8.pdf'>Chapter 8 up to end of 8.3</a><br> <a href='https://arxiv.org/abs/2508.16982'> Chalkidis, 2026</a></td>
       <td>27. Oct. 2026:<br> Post-training: Instruction Tuning & Alignment (<a href='chapters/post_training_llms_slides.pdf'>slides</a>)<br> Sociotechnical Challenges of LLM Alignment (<a href='chapters/sociotechnical_challenges_llms_slides.pdf'>slides</a>) </td>
       <td>30. Oct. 2026: Project help.</td>
       <td></td>


### PR DESCRIPTION
## Summary

- Update course reading links to match the August 19, 2026 release of *Speech and Language Processing* (3rd ed. draft).
- Account for the latest chapter renumbering and the merger of the transformer/pretraining material into Chapter 7.
- Update the post-training subsection reference from 9.3 to 8.3.

## Verification

- Checked the affected readings against the [official SLP3 table of contents](https://web.stanford.edu/~jurafsky/slp3/).
- Ran `git diff --check`.

Documentation-only change; no test suite run.