### PR TITLE
Update 2026-2027 teaching assistants

### DIFF
--- a/chapters/course_logistics.ipynb
+++ b/chapters/course_logistics.ipynb
@@ -96,7 +96,7 @@
     "- **Course Organizer**: [Daniel Hershcovich](https://danielhers.github.io/)\n",
     "- **Teachers**: Daniel Hershcovich and [Desmond Elliott](https://elliottd.github.io/)\n",
     "- **Teaching Assistants**:\n",
-    "    - Ruchira Dhar, Zain Muhammad Mujahid, Yingming Wang, Hu Wanjing (Michelle) and Christian Mølholt Jensen"
+    "    - Emil Høffner, Dominique Julien Rustler, Mathias Nygaard Larsen and Andreas Melbye"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Replace the previous teaching-assistant list in the course logistics notebook.
- Use the four TAs named in the 2026–2027 course planning document: Emil Høffner, Dominique Julien Rustler, Mathias Nygaard Larsen, and Andreas Melbye.

## Verification

- Parsed the notebook as valid JSON.
- Confirmed the previous TA names are absent.
- Ran `git diff --check`.

Documentation-only change; no test suite run.