### PR TITLE
Refocus sequence-labeling slides on the task

### DIFF
--- a/chapters/sequence_labeling_slides.ipynb
+++ b/chapters/sequence_labeling_slides.ipynb
@@ -202,12 +202,12 @@
     }
    },
    "source": [
-    "+ POS tagging\n",
-    "+ Log-linear models\n",
-    "+ IOB encoding\n",
-    "+ Named entity recognition\n",
-    "+ Evaluating sequence labelers\n",
-    "+ Maximum-entropy Markov models"
+    "+ What sequence labelling predicts\n",
+    "+ Parts of speech and named entities\n",
+    "+ BIO/IOB encoding\n",
+    "+ Transparent token-level baselines\n",
+    "+ Imbalance, errors and span evaluation\n",
+    "+ Token alignment, constraints and decoding"
    ]
   },
   {
@@ -220,9 +220,11 @@
    "source": [
     "## Sequence Labelling\n",
     "\n",
-    "+ Assigning exactly one label to each element in a sequence\n",
+    "+ Assign exactly one label to each chosen element in a sequence\n",
     "\n",
-    "+ In context of RNNs or other sequence models, example of **one-to-one** paradigm\n",
+    "+ The output sequence is aligned with the input sequence\n",
+    "\n",
+    "+ Each decision may use the full input context, and neighbouring labels may need to be consistent\n",
     "\n",
     "<center><img src=\"../img/one_to_one.png\"></center>\n",
     "\n",
@@ -621,12 +623,14 @@
     }
    },
    "source": [
-    "## Sequence Labelling as Structured Prediction\n",
+    "## What makes the task structured?\n",
     "\n",
-    "* Input Space $\\Xs$: sequences of items to label\n",
-    "* Output Space $\\Ys$: sequences of output labels\n",
-    "* Model: $s_{\\params}(\\x,\\y)$\n",
-    "* Prediction: $\\argmax_\\y s_{\\params}(\\x,\\y)$"
+    "* The output sequence is aligned with the input sequence\n",
+    "* A token label can depend on context anywhere in the input\n",
+    "* Neighbouring labels can be mutually constrained\n",
+    "* Evaluation may concern individual labels or complete spans\n",
+    "\n",
+    "The **task and its valid outputs** are separate from the model architecture."
    ]
   },
   {
@@ -641,20 +645,14 @@
     }
    },
    "source": [
-    "## Conditional Models\n",
-    "Model probability distributions over label sequences $\\y$ conditioned on input sequences $\\x$\n",
+    "## The output space grows quickly\n",
     "\n",
-    "$$\n",
-    "s_{\\params}(\\x,\\y) = \\prob_\\params(\\y|\\x)\n",
-    "$$\n",
+    "With $n$ positions and $L$ possible labels, there are $L^n$ possible output sequences.\n",
     "\n",
-    "* Just like the conditional models from the [text classification](doc_classify_slides_short.ipynb) chapter\n",
+    "We therefore do not treat each complete label sequence as a separate class. Instead, we:\n",
     "\n",
-    "* But the label space is *exponential* (as a function of sequence length)!\n",
-    "\n",
-    "* Most unique $\\y$ are never even seen in training\n",
-    "\n",
-    "* Might be useful to **break it up**?"
+    "1. score labels at each position; and\n",
+    "2. decide whether and how to model dependencies between labels."
    ]
   },
   {
@@ -669,15 +667,16 @@
     }
    },
    "source": [
-    "## Local Models / Classifiers\n",
-    "A **fully factorised** or **local** model:\n",
+    "## A transparent baseline: classify each token\n",
     "\n",
     "$$\n",
-    "p_\\params(\\y|\\x) = \\prod_{i=1}^n p_\\params(y_i|\\x,i,y_{1,\\ldots,i-1}) \\approx \\prod_{i=1}^n p_\\params(y_i|\\x,i)\n",
+    "\\hat y_i = \\argmax_y p_\\params(y \\mid \\x,i)\n",
     "$$\n",
     "\n",
-    "* Assumption: labels are independent of each other given the input\n",
-    "* Inference in this model is trivial: **greedy decoding**"
+    "* Reuse the multiclass-classification machinery from the previous lecture\n",
+    "* A training instance is a sentence plus a token position\n",
+    "* Features may inspect neighbouring words or the full input\n",
+    "* Labels are predicted independently, so decoding is greedy"
    ]
   },
   {
@@ -688,7 +687,7 @@
     },
     "scrolled": false,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "skip"
     }
    },
    "source": [
@@ -705,7 +704,7 @@
     },
     "scrolled": true,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "skip"
     }
    },
    "source": [
@@ -758,12 +757,12 @@
     }
    },
    "source": [
-    "### Parametrisation\n",
+    "### Reuse a multiclass classifier\n",
     "\n",
-    "**Log-linear multiclass classifier** $p_\\params(y\\bar\\x,i)$ to predict class for sentence $\\x$ and position $i$\n",
+    "A **log-linear multiclass classifier** predicts a label for sentence $\\x$ at position $i$:\n",
     "\n",
     "$$\n",
-    "  p_\\params(y\\bar\\x,i) \\approx \\frac{1}{Z_\\x} \\exp \\langle \\repr(\\x,i),\\params_y \\rangle\n",
+    "  p_\\params(y \\mid \\x,i) = \\frac{1}{Z_{\\x,i}} \\exp \\langle \\repr(\\x,i),\\params_y \\rangle\n",
     "$$\n"
    ]
   },
@@ -775,10 +774,10 @@
     }
    },
    "source": [
-    "+ $\\repr(\\x,i)$ is a **feature function**\n",
-    "+ ${Z_\\x} > 0$ is a normalisation factor to ensure that $\\sum_{y} p_\\params(y\\bar\\x,i) = 1$\n",
+    "+ $\\repr(\\x,i)$ can include the token, prefixes and suffixes, capitalisation, digits and neighbouring tokens\n",
+    "+ The features make this a useful, interpretable baseline\n",
     "\n",
-    "+ How far can we get with very simple features that only consider the word types (and no context)?"
+    "+ How far can we get using only the current word type?"
    ]
   },
   {
@@ -2440,7 +2439,9 @@
     }
    },
    "source": [
-    "## Sequence labelling with neural networks"
+    "## Architecture is one design choice\n",
+    "\n",
+    "The task requires a contextual representation and a label score for each token. Many model families can provide them."
    ]
   },
   {
@@ -2454,13 +2455,13 @@
     }
    },
    "source": [
-    "We can use BiLSTMs for that!\n",
+    "| Context representation | Main contribution |\n",
+    "|-|-|\n",
+    "| Hand-built token and window features | Transparent baseline and interpretable errors |\n",
+    "| Bidirectional recurrent network | Learns left and right context; covered in the RNN lecture |\n",
+    "| Pretrained Transformer | Reuses contextual representations; covered in the Transformer lecture |\n",
     "\n",
-    "<center>\n",
-    "  <img style=\"width:30%;\" src='../img/genthial_bilstm.png'/>\n",
-    "</center>\n",
-    "\n",
-    "<span class=\"font-size:small;\">Source: https://guillaumegenthial.github.io/sequence-tagging-with-tensorflow.html</span>"
+    "The label scheme and evaluation stay the same."
    ]
   },
   {
@@ -2474,50 +2475,15 @@
     }
    },
    "source": [
-    "### Reminder\n",
-    "A recurrent neural network (plain RNN, LSTM, GRU, ...) computes its output based on a hidden, internal state:\n",
+    "### Start from the task requirements\n",
     "\n",
-    "$$\n",
-    " {\\mathbf{y}}_{t} = \\text{RNN}(\\x_t, {\\mathbf{h}}_{t})\n",
-    "$$\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
+    "Before choosing a model, decide:\n",
     "\n",
-    "A **bi-directional** RNN is just two uni-directional RNNs combined:\n",
-    "\n",
-    "\\begin{align}\n",
-    " \\overrightarrow{\\mathbf{y}_{t}} & = \\overrightarrow{\\text{RNN}}(\\x_t, \\overrightarrow{\\mathbf{h}_{t}})\\\\\n",
-    " \\overleftarrow{\\mathbf{y}_{t}} & = \\overleftarrow{\\text{RNN}}(\\x_t, \\overleftarrow{\\mathbf{h}_{t}})\n",
-    " \\\\\n",
-    " {\\mathbf{y}}_{t} & = \\overrightarrow{\\mathbf{y}_{t}} \\oplus \\overleftarrow{\\mathbf{y}_{t}} \\\\\n",
-    "\\end{align}\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "To predict label probabilities, we use the **softmax function**:\n",
-    "\n",
-    "\n",
-    "$$\n",
-    "\\begin{aligned}\n",
-    " {\\mathbf{y}}_{t} & = \\overrightarrow{\\mathbf{y}_{t}} \\oplus \\overleftarrow{\\mathbf{y}_{t}} \\\\\n",
-    " \\hat{\\mathbf{y}}_{t} & = \\text{softmax}(\\mathbf{W}^o \\mathbf{y}_{t}) \\in \\mathbb{R}^{|V|} \\\\\n",
-    "\\end{aligned}\n",
-    "$$\n"
+    "* what receives a label: words, subwords, characters or another unit;\n",
+    "* which context can change the correct label;\n",
+    "* which label transitions are valid;\n",
+    "* how class imbalance affects the baseline; and\n",
+    "* whether success is measured per token or per span."
    ]
   },
   {
@@ -2528,8 +2494,50 @@
     }
    },
    "source": [
-    "We can also use transformers such as BERT\n",
-    "![bert_ner](../img/bert_ner.png)"
+    "### Tokenisation is part of the task\n",
+    "\n",
+    "Gold annotations and model inputs may use different units. A word-level label must therefore be aligned with any subwords used internally.\n",
+    "\n",
+    "| Gold words | Copenhagen | hosts | ... |\n",
+    "|-|-|-|-|\n",
+    "| Gold labels | B-GPE | O | ... |\n",
+    "| Model tokens | Copen, ##hagen | hosts | ... |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Alignment must be reversible\n",
+    "\n",
+    "One common convention assigns the word label to its first subword and ignores the others in the loss. Whatever convention you choose:\n",
+    "\n",
+    "1. test alignment in both directions;\n",
+    "2. map predictions back to the annotated units; and\n",
+    "3. evaluate spans only after that mapping."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Decoding is separate from encoding\n",
+    "\n",
+    "Once a model scores labels at every position, we still decide how to form the output sequence:\n",
+    "\n",
+    "* **independent argmax:** a strong, simple baseline;\n",
+    "* **validity constraints:** mask or repair impossible BIO/IOB transitions; or\n",
+    "* **sequence search:** use transition scores with beam search or dynamic programming.\n",
+    "\n",
+    "These choices can sit above feature-based, recurrent or Transformer representations."
    ]
   },
   {
@@ -3749,14 +3757,10 @@
    "source": [
     "## Summary\n",
     "\n",
-    "\n",
-    "- Many problems can be cast as sequence labelling\n",
-    "    - POS tagging\n",
-    "    - Named entity recognition (with IOB encoding)\n",
-    "    \n",
-    "- Models are similar to sequence **classifiers** but are sequential\n",
-    "    - Log-linear models rely on good feature engineering\n",
-    "    - Neural sequence labelers rely on substantial amounts of training data but generally perform better\n"
+    "- Sequence labelling assigns one label per input unit, with possible constraints across labels\n",
+    "- POS uses token tags; NER uses BIO/IOB tags to encode spans\n",
+    "- Start with an interpretable token classifier; inspect imbalance and errors, then evaluate complete spans\n",
+    "- Alignment and decoding are system choices; RNNs and Transformers are alternative context encoders\n"
    ]
   },
   {
@@ -3782,9 +3786,9 @@
    },
    "source": [
     "* Jurafsky & Martin, *Speech and Language Processing*, [Chapter 18: Sequence Labeling](https://web.stanford.edu/~jurafsky/slp3/18.pdf)\n",
-    "* Sutton & McCallum, [An Introduction to Conditional Random Fields for Relational Learning](https://people.cs.umass.edu/~mccallum/papers/crf-tutorial.pdf)\n",
-    "* Huang et al., [Bidirectional LSTM-CRF Models for Sequence Tagging](https://arxiv.org/abs/1508.01991)\n",
-    "* Andor et al., [Globally Normalized Transition-Based Neural Networks](https://arxiv.org/abs/1603.06042)"
+    "* Tjong Kim Sang & De Meulder, [Introduction to the CoNLL-2003 Shared Task: Language-Independent Named Entity Recognition](https://aclanthology.org/W03-0419/)\n",
+    "* Optional structured-model background: Sutton & McCallum, [An Introduction to Conditional Random Fields for Relational Learning](https://people.cs.umass.edu/~mccallum/papers/crf-tutorial.pdf)\n",
+    "* Neural architectures are covered in the later RNN and Transformer lectures"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

- reframe sequence labelling around aligned inputs and outputs, contextual decisions, label constraints, and token- versus span-level evaluation
- replace the detailed BiLSTM/RNN equations and BERT walkthrough with one concise model-choice comparison that defers architecture details to the later lectures
- make the simple per-token classifier an explicit, interpretable baseline
- add task-focused guidance on word/subword label alignment, reversible span mapping, BIO/IOB validity, and decoding choices
- update the overview, summary, and background reading accordingly

## Validation

- parsed the notebook successfully as JSON
- exported it successfully with `nbconvert --to slides`
- checked every revised slide for density and wrapping; the layout test reports no overflow
- verified that visible RNN/Transformer mentions are limited to the model comparison, decoding context, summary, and lecture pointers
- ran `git diff --check`