### PR TITLE
Add public project student starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 Materials from this interactive book are used throughout the Natural Language Processing course at the Department of Computer Science, University of Copenhagen. The official course description can be found [here](https://kurser.ku.dk/course/ndak18000u). Materials covered each week are listed below. The course schedule and materials are tentative and subject to minor changes. Most reading material is from [Speech and Language Processing by Jurafsky & Martin](https://web.stanford.edu/~jurafsky/slp3).
 
+## Course project
+
+The student-facing [project starter](student_starter/) contains the challenge-set validator, a valid format example and usage instructions.
+
 <table>
    <tr>
       <th>Week</th>

--- a/student_starter/README.md
+++ b/student_starter/README.md
@@ -1,0 +1,18 @@
+# Challenge-set starter
+
+Copy `validate_challenge.py` and use it on the final `challenge.json`:
+
+```bash
+python validate_challenge.py challenge.json
+```
+
+The default requires ten records (five matched pairs) per value of
+`created_by`. To check the two-record format example:
+
+```bash
+python validate_challenge.py example_challenge.json --expected-per-member 2
+```
+
+The validator checks required fields, unique IDs, creator counts, pair balance,
+shared pair metadata, public-looking source URLs, exact answer substrings and
+the required representation of unanswerable examples.

--- a/student_starter/__init__.py
+++ b/student_starter/__init__.py
@@ -1,0 +1,1 @@
+"""Student-facing utilities distributed with the project description."""

--- a/student_starter/example_challenge.json
+++ b/student_starter/example_challenge.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "example-bridge-answerable",
+    "pair_id": "example-bridge",
+    "created_by": "example-author",
+    "question": "Hvornår åbnede Øresundsbroen?",
+    "context": "The Øresund Bridge opened on 1 July 2000 and connects Copenhagen with Malmö.",
+    "lang": "da",
+    "answerable": true,
+    "answer_start": 29,
+    "answer": "1 July 2000",
+    "source_url": "https://en.wikipedia.org/wiki/%C3%98resund_Bridge"
+  },
+  {
+    "id": "example-bridge-unanswerable",
+    "pair_id": "example-bridge",
+    "created_by": "example-author",
+    "question": "Hvornår lukkede Øresundsbroen?",
+    "context": "The Øresund Bridge opened on 1 July 2000 and connects Copenhagen with Malmö.",
+    "lang": "da",
+    "answerable": false,
+    "answer_start": -1,
+    "answer": "",
+    "source_url": "https://en.wikipedia.org/wiki/%C3%98resund_Bridge"
+  }
+]

--- a/student_starter/validate_challenge.py
+++ b/student_starter/validate_challenge.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate the schema, answer offsets and matched pairs in challenge.json."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence
+
+
+REQUIRED_FIELDS = {
+    "id",
+    "pair_id",
+    "created_by",
+    "question",
+    "context",
+    "lang",
+    "answerable",
+    "answer_start",
+    "answer",
+    "source_url",
+}
+
+
+def validate_records(
+    records: Sequence[Mapping[str, Any]], expected_per_member: int = 10
+) -> list[str]:
+    errors: list[str] = []
+    ids: set[str] = set()
+    pairs: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    member_counts: Counter[str] = Counter()
+
+    for index, record in enumerate(records):
+        prefix = f"record {index}"
+        if not isinstance(record, Mapping):
+            errors.append(f"{prefix}: must be a JSON object")
+            continue
+        missing = sorted(REQUIRED_FIELDS - set(record))
+        if missing:
+            errors.append(f"{prefix}: missing fields {missing}")
+            continue
+
+        record_id = record["id"]
+        if not isinstance(record_id, str) or not record_id.strip():
+            errors.append(f"{prefix}: id must be a non-empty string")
+        elif record_id in ids:
+            errors.append(f"{prefix}: duplicate id {record_id!r}")
+        else:
+            ids.add(record_id)
+
+        pair_id = record["pair_id"]
+        creator = record["created_by"]
+        if not isinstance(pair_id, str) or not pair_id.strip():
+            errors.append(f"{prefix}: pair_id must be a non-empty string")
+        else:
+            pairs[pair_id].append(record)
+        if not isinstance(creator, str) or not creator.strip():
+            errors.append(f"{prefix}: created_by must be a non-empty string")
+        else:
+            member_counts[creator] += 1
+
+        for field in ("question", "context", "lang"):
+            if not isinstance(record[field], str) or not record[field].strip():
+                errors.append(f"{prefix}: {field} must be a non-empty string")
+        if not isinstance(record["source_url"], str) or not re.match(
+            r"^https?://", record["source_url"]
+        ):
+            errors.append(f"{prefix}: source_url must start with http:// or https://")
+
+        answerable = record["answerable"]
+        start = record["answer_start"]
+        answer = record["answer"]
+        context = record["context"]
+        if not isinstance(answerable, bool):
+            errors.append(f"{prefix}: answerable must be a JSON boolean")
+            continue
+        if not isinstance(start, int) or isinstance(start, bool):
+            errors.append(f"{prefix}: answer_start must be an integer")
+            continue
+        if not isinstance(answer, str):
+            errors.append(f"{prefix}: answer must be a string")
+            continue
+        if answerable:
+            if not answer:
+                errors.append(f"{prefix}: answerable record must have a non-empty answer")
+            elif start < 0 or context[start : start + len(answer)] != answer:
+                errors.append(f"{prefix}: answer and answer_start do not match context")
+        elif start != -1 or answer != "":
+            errors.append(
+                f"{prefix}: unanswerable record must use answer_start=-1 and an empty answer"
+            )
+
+    for member, count in sorted(member_counts.items()):
+        if count != expected_per_member:
+            errors.append(
+                f"member {member!r}: expected {expected_per_member} records, found {count}"
+            )
+
+    for pair_id, pair_records in sorted(pairs.items()):
+        if len(pair_records) != 2:
+            errors.append(f"pair {pair_id!r}: expected 2 records, found {len(pair_records)}")
+            continue
+        for field in ("context", "lang", "created_by", "source_url"):
+            if pair_records[0][field] != pair_records[1][field]:
+                errors.append(f"pair {pair_id!r}: {field} must be identical")
+        if {pair_records[0]["answerable"], pair_records[1]["answerable"]} != {False, True}:
+            errors.append(f"pair {pair_id!r}: exactly one record must be answerable")
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, nargs="?", default=Path("challenge.json"))
+    parser.add_argument("--expected-per-member", type=int, default=10)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    records = json.loads(args.path.read_text(encoding="utf-8"))
+    if not isinstance(records, list):
+        raise SystemExit("challenge file must contain a JSON array")
+    errors = validate_records(records, expected_per_member=args.expected_per_member)
+    if errors:
+        print("Challenge set is invalid:")
+        for error in errors:
+            print(f"- {error}")
+        raise SystemExit(1)
+    print(f"Challenge set is valid: {len(records)} records.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add the student-facing challenge-set validator to the public course repository
- include a valid two-record matched-pair example and usage instructions
- link the starter from the course README
- exclude all instructor reference-solution and test files

## Validation

- confirmed the public directory exactly matches the student-facing source
- `python student_starter/validate_challenge.py student_starter/example_challenge.json --expected-per-member 2` passes
- confirmed that an incorrect answer offset is rejected
- `python -m py_compile student_starter/validate_challenge.py`
- `git diff --check`