### PR TITLE
Expand Lab 1 Colab and BPE exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Materials from this interactive book are used throughout the Natural Language Pr
       <td>36</td>
       <td> <a href='https://web.stanford.edu/~jurafsky/slp3/2.pdf'>Chapter 2</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/4.pdf'>Chapter 4</a></td>
       <td>1. Sep. 2026:<br> Course Logistics (<a href='chapters/course_logistics.ipynb'>slides</a>)<br> Introduction to NLP (<a href='chapters/intro_short.ipynb'>slides</a>)<br> Tokenisation &amp; Sentence Splitting (<a href='chapters/tokenization.ipynb'>notes</a>, <a href='chapters/tokenization_slides.ipynb'>slides</a>, <a href='exercises/tokenization.ipynb'>exercises</a>)<br> Text Classification (<a href='chapters/doc_classify_slides_short.ipynb'>slides</a>)<br> </td>
-      <td>4. &amp; 7. Sep. 2026:<br> Jupyter notebook setup, introduction to <a href='https://colab.research.google.com/'>Colab</a><br> Introduction to <a href='https://pytorch.org/tutorials/'>PyTorch</a><br> Project group arrangements<br> Questions about the course project<br> </td>
+      <td>4. &amp; 7. Sep. 2026:<br> Google <a href='https://colab.research.google.com/'>Colab</a> and notebook workflow<br> BPE algorithm and subword tokenisation<br> Introduction to <a href='https://pytorch.org/tutorials/'>PyTorch</a><br> Project group arrangements<br> Questions about the course project<br> </td>
       <td><a href='labs/notebooks_2026/lab_1.ipynb'>lab 1</a></td>
    </tr>
    <tr>

--- a/chapters/course_logistics.ipynb
+++ b/chapters/course_logistics.ipynb
@@ -165,7 +165,7 @@
        "      <td>36</td>\n",
        "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/2.pdf'>Chapter 2</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/4.pdf'>Chapter 4</a></td>\n",
        "      <td>1. Sep. 2026:<br> Course Logistics (<a href='../chapters/course_logistics.ipynb'>slides</a>)<br> Introduction to NLP (<a href='../chapters/intro_short.ipynb'>slides</a>)<br> Tokenisation &amp; Sentence Splitting (<a href='../chapters/tokenization.ipynb'>notes</a>, <a href='../chapters/tokenization_slides.ipynb'>slides</a>, <a href='../exercises/tokenization.ipynb'>exercises</a>)<br> Text Classification (<a href='../chapters/doc_classify_slides_short.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>4. &amp; 7. Sep. 2026:<br> Jupyter notebook setup, introduction to <a href='https://colab.research.google.com/'>Colab</a><br> Introduction to <a href='https://pytorch.org/tutorials/'>PyTorch</a><br> Project group arrangements<br> Questions about the course project<br> </td>\n",
+       "      <td>4. &amp; 7. Sep. 2026:<br> Google <a href='https://colab.research.google.com/'>Colab</a> and notebook workflow<br> BPE algorithm and subword tokenisation<br> Introduction to <a href='https://pytorch.org/tutorials/'>PyTorch</a><br> Project group arrangements<br> Questions about the course project<br> </td>\n",
        "      <td><a href='../labs/notebooks_2026/lab_1.ipynb'>lab 1</a></td>\n",
        "   </tr>\n",
        "   <tr>\n",

--- a/labs/notebooks_2026/lab_1.ipynb
+++ b/labs/notebooks_2026/lab_1.ipynb
@@ -36,10 +36,11 @@
     "\n",
     "By the end of this lab, you should be able to:\n",
     "\n",
-    "1. open, copy and run a notebook in Google Colab;\n",
-    "2. compare rule-based, word-level and subword tokenisation;\n",
-    "3. explain the core parts of a small PyTorch classifier; and\n",
-    "4. locate the project instructions and form a project group."
+    "1. copy, run, restart and save a notebook in Google Colab;\n",
+    "2. trace BPE pair counts and merge operations by hand and in code;\n",
+    "3. compare rule-based, word-level and subword tokenisation;\n",
+    "4. explain the core parts of a small PyTorch classifier; and\n",
+    "5. locate the project instructions and form a project group."
    ]
   },
   {
@@ -50,8 +51,8 @@
    "source": [
     "## TA session plan\n",
     "\n",
-    "1. Open the notebook in Colab and save a working copy in Drive.\n",
-    "2. Compare the word-level and subword tokenisers.\n",
+    "1. Complete the required Colab checkpoint: copy, run, restart and save the notebook.\n",
+    "2. Work through the BPE example, including pair counts, merges and unseen-word encoding.\n",
     "3. Train and evaluate the small PyTorch classifier.\n",
     "4. Form a project group and use the remaining time for project questions."
    ]
@@ -273,6 +274,55 @@
     "**The code cells below have to be run in a Colab environment!**\n",
     "#### Uploading files from your local file system\n",
     "files.upload returns a dictionary of the files which were uploaded. The dictionary is keyed by the file name and values are the data which were uploaded."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Required Colab checkpoint: runtime, state and storage\n",
+    "\n",
+    "Complete these steps with a partner before continuing:\n",
+    "\n",
+    "1. Open the repository notebook in Colab and select **File → Save a copy in Drive**.\n",
+    "2. Run the next cell and identify the Python version, working directory and accelerator status.\n",
+    "3. Change `colab_session_value`, rerun the cell, then select **Runtime → Restart session**. Predict what will happen if you try to print the variable before rerunning the cell.\n",
+    "4. Select **Runtime → Run all** and confirm that the notebook works from a clean state.\n",
+    "\n",
+    "The notebook file saved in Drive persists. Python variables disappear when the runtime restarts, and files or installed packages on the temporary Colab machine may disappear when its runtime is reset or recycled. Keep installation commands near the top of the notebook and store important data in Drive or another durable location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import platform\n",
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    import google.colab  # type: ignore\n",
+    "    running_in_colab = True\n",
+    "except ImportError:\n",
+    "    running_in_colab = False\n",
+    "\n",
+    "print(\"Running in Colab:\", running_in_colab)\n",
+    "print(\"Python:\", sys.version.split()[0])\n",
+    "print(\"Working directory:\", os.getcwd())\n",
+    "print(\"Platform:\", platform.platform())\n",
+    "\n",
+    "try:\n",
+    "    import torch\n",
+    "    print(\"GPU available:\", torch.cuda.is_available())\n",
+    "    if torch.cuda.is_available():\n",
+    "        print(\"GPU:\", torch.cuda.get_device_name(0))\n",
+    "except ImportError:\n",
+    "    print(\"PyTorch is not installed in this runtime yet.\")\n",
+    "\n",
+    "colab_session_value = 42\n",
+    "print(\"Session value:\", colab_session_value)"
    ]
   },
   {
@@ -618,6 +668,208 @@
     "nlp_fr = spacy.load(\"fr_core_news_sm\")\n",
     "print([token.text for token in nlp_fr(\"On nous dit qu’aujourd’hui c’est le cas, encore faudra-t-il l’évaluer.\")])\n",
     "nltk.tokenize.word_tokenize(\"On nous dit qu’aujourd’hui c’est le cas, encore faudra-t-il l’évaluer.\", language='french')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Byte-pair encoding (BPE): learning subwords from counts\n",
+    "\n",
+    "BPE learns a subword vocabulary from a training corpus:\n",
+    "\n",
+    "1. represent every word as characters plus an end-of-word marker;\n",
+    "2. count adjacent symbol pairs, weighted by word frequency;\n",
+    "3. merge the most frequent pair into one new symbol; and\n",
+    "4. repeat until reaching the chosen number of merges or vocabulary size.\n",
+    "\n",
+    "At test time, start from characters and apply the learned merges in the same order. Frequent sequences become larger tokens, while rare and unseen words can still be represented using smaller pieces.\n",
+    "\n",
+    "The toy implementation below uses character symbols and `</w>` as a word-boundary marker. Production tokenisers differ in their initial symbols, normalisation and scoring: BERT uses WordPiece, while several other models use BPE or SentencePiece variants. The common idea is to learn reusable subword units from data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Worked corpus\n",
+    "\n",
+    "We use the following word-frequency table:\n",
+    "\n",
+    "| word | frequency | initial symbols |\n",
+    "|---|---:|---|\n",
+    "| `low` | 5 | `l o w </w>` |\n",
+    "| `lower` | 2 | `l o w e r </w>` |\n",
+    "| `newest` | 6 | `n e w e s t </w>` |\n",
+    "| `widest` | 3 | `w i d e s t </w>` |\n",
+    "\n",
+    "Before running the next cell, calculate the count of `(l, o)` and find the most frequent pair or tied pairs. Each occurrence is multiplied by the frequency of its word."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "toy_word_counts = {\"low\": 5, \"lower\": 2, \"newest\": 6, \"widest\": 3}\n",
+    "\n",
+    "\n",
+    "def initialise_bpe_vocabulary(word_counts):\n",
+    "    return {tuple(word) + (\"</w>\",): frequency for word, frequency in word_counts.items()}\n",
+    "\n",
+    "\n",
+    "def adjacent_pair_counts(vocabulary):\n",
+    "    counts = Counter()\n",
+    "    for symbols, frequency in vocabulary.items():\n",
+    "        for left, right in zip(symbols, symbols[1:]):\n",
+    "            counts[(left, right)] += frequency\n",
+    "    return counts\n",
+    "\n",
+    "\n",
+    "initial_vocabulary = initialise_bpe_vocabulary(toy_word_counts)\n",
+    "initial_counts = adjacent_pair_counts(initial_vocabulary)\n",
+    "\n",
+    "print(\"Count of ('l', 'o'):\", initial_counts[(\"l\", \"o\")])\n",
+    "print(\"Ten most frequent pairs:\")\n",
+    "for pair, count in initial_counts.most_common(10):\n",
+    "    print(f\"  {pair}: {count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### One merge step\n",
+    "\n",
+    "Replace every adjacent occurrence of the selected pair with its concatenation. If several pairs have the same maximum count, a real implementation needs a deterministic tie-breaking rule. This notebook chooses the lexicographically smallest tied pair so that everyone obtains the same trace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def choose_most_frequent_pair(counts):\n",
+    "    highest_count = max(counts.values())\n",
+    "    tied_pairs = [pair for pair, count in counts.items() if count == highest_count]\n",
+    "    return min(tied_pairs), highest_count\n",
+    "\n",
+    "\n",
+    "def merge_symbols(symbols, pair):\n",
+    "    merged = []\n",
+    "    index = 0\n",
+    "    while index < len(symbols):\n",
+    "        if index + 1 < len(symbols) and (symbols[index], symbols[index + 1]) == pair:\n",
+    "            merged.append(\"\".join(pair))\n",
+    "            index += 2\n",
+    "        else:\n",
+    "            merged.append(symbols[index])\n",
+    "            index += 1\n",
+    "    return merged\n",
+    "\n",
+    "\n",
+    "def merge_vocabulary(vocabulary, pair):\n",
+    "    result = Counter()\n",
+    "    for symbols, frequency in vocabulary.items():\n",
+    "        result[tuple(merge_symbols(list(symbols), pair))] += frequency\n",
+    "    return dict(result)\n",
+    "\n",
+    "\n",
+    "first_pair, first_count = choose_most_frequent_pair(initial_counts)\n",
+    "vocabulary_after_one_merge = merge_vocabulary(initial_vocabulary, first_pair)\n",
+    "\n",
+    "print(\"Selected pair:\", first_pair, \"with count\", first_count)\n",
+    "for symbols, frequency in vocabulary_after_one_merge.items():\n",
+    "    print(f\"  {frequency:2d} × {' '.join(symbols)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Learn several merges\n",
+    "\n",
+    "The loop below repeats the same operation. Read the printed trace as an algorithm: the counts are recomputed after every merge because the available adjacent pairs have changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def learn_bpe(word_counts, number_of_merges):\n",
+    "    vocabulary = initialise_bpe_vocabulary(word_counts)\n",
+    "    merges = []\n",
+    "\n",
+    "    for step in range(1, number_of_merges + 1):\n",
+    "        counts = adjacent_pair_counts(vocabulary)\n",
+    "        if not counts:\n",
+    "            break\n",
+    "        pair, count = choose_most_frequent_pair(counts)\n",
+    "        merges.append(pair)\n",
+    "        vocabulary = merge_vocabulary(vocabulary, pair)\n",
+    "        print(f\"{step:2d}. merge {pair} (count={count})\")\n",
+    "\n",
+    "    return merges, vocabulary\n",
+    "\n",
+    "\n",
+    "learned_merges, learned_vocabulary = learn_bpe(toy_word_counts, number_of_merges=8)\n",
+    "\n",
+    "print(\"\\nVocabulary after eight merges:\")\n",
+    "for symbols, frequency in learned_vocabulary.items():\n",
+    "    print(f\"  {frequency:2d} × {' '.join(symbols)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Apply the learned merges to new words\n",
+    "\n",
+    "Encoding does **not** count pairs again. It applies the training-time merges in their learned order. This lets the tokeniser reuse frequent pieces while retaining a character-level fallback for unseen forms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def encode_with_bpe(word, merges):\n",
+    "    symbols = list(word) + [\"</w>\"]\n",
+    "    for pair in merges:\n",
+    "        symbols = merge_symbols(symbols, pair)\n",
+    "\n",
+    "    tokens = []\n",
+    "    for symbol in symbols:\n",
+    "        if symbol == \"</w>\":\n",
+    "            continue\n",
+    "        tokens.append(symbol.removesuffix(\"</w>\"))\n",
+    "    return tokens\n",
+    "\n",
+    "\n",
+    "for word in [\"low\", \"lower\", \"lowest\", \"newer\", \"widest\"]:\n",
+    "    tokens = encode_with_bpe(word, learned_merges)\n",
+    "    print(f\"{word:7s} -> {tokens}\")\n",
+    "    assert \"\".join(tokens) == word"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### BPE exercise\n",
+    "\n",
+    "1. Explain why `(l, o)` has count 7 rather than 2.\n",
+    "2. Carry out the first merge on paper and compare your result with the code.\n",
+    "3. Compare the tokens for `low`, `lower`, `lowest` and `newer`. Which pieces transfer to unseen words?\n",
+    "4. Change the number of merges from 8 to 20. What happens to token length and vocabulary size? Why is the number of merges a modelling choice?\n",
+    "5. In one sentence, contrast word-level tokenisation with BPE for a word that never appeared in the training corpus."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- make the Colab workflow a required Lab 1 checkpoint: copy, run, inspect the runtime, restart, run all, and save
- explain transient runtime state and durable storage
- add a worked BPE corpus with frequency-weighted pair counts
- implement deterministic pair selection, one merge step, repeated training, and application of learned merges to unseen words
- add a five-part BPE exercise covering manual calculation, transfer to unseen words, and the merge-budget trade-off
- update the README and cached logistics schedule to name Colab and BPE explicitly

The notebook distinguishes the toy BPE implementation from WordPiece and SentencePiece variants used by production models.

## Validation

- executed the Colab checkpoint cell outside Colab, including its environment fallback
- executed every new BPE code cell sequentially
- verified the learned tokenizer reconstructs all example words exactly
- validated notebook-v4 JSON, the cached schedule, and all 45 README links
- `git diff --check` passes