### PR TITLE
Tighten first lecture and make tokenization concrete

### DIFF
--- a/chapters/course_logistics.ipynb
+++ b/chapters/course_logistics.ipynb
@@ -67,557 +67,183 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "# NDAK18000U Overview\n",
+    "# Natural Language Processing\n",
     "\n",
-    "Course materials: [github.com/coastalcph/nlp-course](https://github.com/coastalcph/nlp-course)."
+    "### NDAK18000U · Autumn 2026\n",
+    "\n",
+    "Course materials: [github.com/coastalcph/nlp-course](https://github.com/coastalcph/nlp-course)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### NDAK18000U Details\n",
+    "## Teaching team\n",
     "\n",
-    "- **Course Organizer**: Daniel Hershcovich\n",
-    "- **Teachers**: Daniel Hershcovich, Mansi Goel, Desmond Elliott and Shanshan Xu\n",
-    "- **Teaching Assistants**: Emil Høffner, Dominique Julien Rustler, Mathias Nygaard Larsen and Andreas Melbye"
+    "**Course organizer:** Daniel Hershcovich\n",
+    "\n",
+    "**Teachers:** Daniel Hershcovich, Mansi Goel, Desmond Elliott and Shanshan Xu\n",
+    "\n",
+    "**Teaching assistants:** Emil Høffner, Dominique Julien Rustler, Mathias Nygaard Larsen and Andreas Melbye"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### NDAK18000U Schedule\n",
+    "## When and where\n",
     "\n",
-    "- Lectures:  \n",
-    "    -  Tuesdays, 13:15-15:00 in HCØ Auditorium 5 (Universitetsparken 5), Weeks 36-41 + 43-44\n",
-    "    \n",
-    "- Lab Sessions:\n",
-    "    - Group 1: Mondays, 8:15-10:00 in Biocenter 4-0-10 (Ole Maaløes Vej 5), Weeks 37-41 + 43-44\n",
-    "    - Group 2: Fridays, 8:15-10:00 in Biocenter 4-0-24 (Ole Maaløes Vej 5), Weeks 36-41 + 43-44\n",
+    "**Lectures:** Tuesdays 13:15–15:00 · HCØ Auditorium 5 · Weeks 36–41 and 43–44\n",
     "\n",
-    "We will assign you to one of two lab session groups based on your answers to the [Getting to Know You survey](https://absalon.instructure.com/courses/91709/assignments/268606).\n",
-    "If you have not filled it in yet, do it as soon as possible.\n",
-    "You will receive an announcement about your assignment before the first lab session."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%cd .."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "# Natural Language Processing (NDAK18000U)\n",
-       "## Course at the University of Copenhagen\n",
-       "\n",
-       "Materials from this interactive book are used throughout the Natural Language Processing course at the Department of Computer Science, University of Copenhagen. The official course description can be found [here](https://kurser.ku.dk/course/ndak18000u). Materials covered each week are listed below. The course schedule and materials are tentative and subject to minor changes. Most reading material is from [Speech and Language Processing by Jurafsky & Martin](https://web.stanford.edu/~jurafsky/slp3).\n",
-       "\n",
-       "<table>\n",
-       "   <tr>\n",
-       "      <th>Week</th>\n",
-       "      <th>Reading (before lecture)</th>\n",
-       "      <th>Lecture (Tuesday)</th>\n",
-       "      <th>Lab (Friday &amp; Monday)</th>\n",
-       "      <th>Lab notebook</th>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>36</td>\n",
-       "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/2.pdf'>Chapter 2</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/4.pdf'>Chapter 4</a></td>\n",
-       "      <td>1. Sep. 2026:<br> Course Logistics (<a href='../chapters/course_logistics.ipynb'>slides</a>)<br> Introduction to NLP (<a href='../chapters/intro_short.ipynb'>slides</a>)<br> Tokenisation &amp; Sentence Splitting (<a href='../chapters/tokenization.ipynb'>notes</a>, <a href='../chapters/tokenization_slides.ipynb'>slides</a>, <a href='../exercises/tokenization.ipynb'>exercises</a>)<br> Text Classification (<a href='../chapters/doc_classify_slides_short.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>4. &amp; 7. Sep. 2026:<br> Google <a href='https://colab.research.google.com/'>Colab</a> and notebook workflow<br> BPE algorithm and subword tokenisation<br> Introduction to <a href='https://pytorch.org/tutorials/'>PyTorch</a><br> Project group arrangements<br> Questions about the course project<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_1.ipynb'>lab 1</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>37</td>\n",
-       "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/18.pdf'>Chapter 18</a></td>\n",
-       "      <td>8. Sep. 2026:<br> Sequence Labelling (<a href='../chapters/sequence_labeling_slides.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>11. &amp; 14. Sep. 2026:<br> Sequence labelling and beam search<br> Project help<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_2.ipynb'>lab 2</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>38</td>\n",
-       "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/3.pdf'>Chapter 3</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/5.pdf'>Chapter 5</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/6.pdf'>Chapter 6</a></td>\n",
-       "      <td>15. Sep. 2026:<br> Language Modelling (<a href='../chapters/language_models_slides.ipynb'>slides</a>)<br> Word Embeddings (<a href='../chapters/dl-representations_simple.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>18. &amp; 21. Sep. 2026:<br> Word representations and sentiment classification<br> Project help<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_3.ipynb'>lab 3</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>39</td>\n",
-       "      <td><a href='https://web.stanford.edu/~jurafsky/slp3/14.pdf'>Chapter 14</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/7.pdf'>Chapter 7</a> </td>\n",
-       "      <td>22. Sep. 2026:<br> Recurrent Neural Networks (<a href='../chapters/rnn_slides_ucph.ipynb'>slides</a>)<br> Neural Language Models (<a href='../chapters/dl-representations_contextual.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>25. &amp; 28. Sep. 2026:<br> Error analysis and explainability<br> Project help<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_4.ipynb'>lab 4</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>40</td>\n",
-       "      <td><a href='https://web.stanford.edu/~jurafsky/slp3/7.pdf'>Chapter 7</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/9.pdf'>Chapter 9</a></td>\n",
-       "      <td>29. Sep. 2026:<br> Attention (<a href='../chapters/attention_slides2.ipynb'>slides</a>)<br> Transformers (<a href='../chapters/dl-representations_contextual_transformers.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>2. &amp; 5. Oct. 2026:<br> Language Models with <a href='https://huggingface.co/learn/llm-course/chapter1/1'>Transformers</a> and RNNs<br> Project help<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_5.ipynb'>lab 5</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>41</td>\n",
-       "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/21.pdf'>Chapter 21</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/11.pdf'>Chapter 11, Section 11.6</a><br><a href=\"https://aclanthology.org/2020.tacl-1.30.pdf\">Clark et al., 2020</a> </td>\n",
-       "      <td>6. Oct. 2026:<br> Information Extraction (<a href='../chapters/information_extraction_slides.ipynb'>slides</a>)<br> Question Answering (<a href='../chapters/question_answering_slides.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>9. &amp; 19. Oct. 2026:<br> In-depth look at Transformers and Multilingual QA<br> Project help<br> </td>\n",
-       "      <td><a href='../labs/notebooks_2026/lab_6.ipynb'>lab 6</a></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>43</td>\n",
-       "      <td> <a href=\"https://aclanthology.org/2022.acl-long.482.pdf\">Hershcovich et al., 2022</a><br> <a href='https://arxiv.org/abs/2508.16982'>Chalkidis, 2026</a></td>\n",
-       "      <td>20. Oct. 2026:<br> Multilingual and Multicultural NLP (<a href='../chapters/xling_transfer_learning_slides.ipynb'>slides</a>)<br> Sociotechnical Challenges of LLM Alignment (<a href='../chapters/sociotechnical_challenges_llms_slides.pdf'>slides</a>)<br> </td>\n",
-       "      <td>23. &amp; 26. Oct. 2026: Project help.</td>\n",
-       "      <td></td>\n",
-       "   </tr>\n",
-       "   <tr>\n",
-       "      <td>44</td>\n",
-       "      <td> <a href='https://web.stanford.edu/~jurafsky/slp3/20.pdf'>Chapter 20</a><br> <a href='https://web.stanford.edu/~jurafsky/slp3/13.pdf'>Chapter 13</a></td>\n",
-       "      <td>27. Oct. 2026:<br> Parsing (<a href='../chapters/dependency_parsing_slides_active.ipynb'>slides</a>)<br> Machine Translation (<a href='../chapters/nmt_slides_active.ipynb'>slides</a>)<br> </td>\n",
-       "      <td>30. Oct. 2026: Project help.</td>\n",
-       "      <td></td>\n",
-       "   </tr>\n",
-       "</table>\n",
-       "The easiest way to view the course content is via the static [nbviewer](https://nbviewer.jupyter.org/github/coastalcph/nlp-course/blob/master/overview.ipynb). \n",
-       "To be able to make changes to the book and render it dynamically, see the [installation instructions](INSTALL.md).\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import re\n",
-    "from IPython.display import Markdown, display\n",
+    "**Monday lab:** 08:15–10:00 · Biocenter 4-0-10 · Weeks 37–41 and 43–44\n",
     "\n",
-    "with open('../README.md', 'r') as f:\n",
-    "    content = f.read()\n",
+    "**Friday lab:** 08:15–10:00 · Biocenter 4-0-24 · Weeks 36–41 and 43–44\n",
     "\n",
-    "# Regular expression to find all <a href=\"...\"> that don't start with 'http'\n",
-    "pattern = re.compile(r'<a href=([\\'\"])(?!http)([^\\'\"]+)\\1>')\n",
-    "\n",
-    "# Function to prepend '../' to each link\n",
-    "def replacer(match):\n",
-    "    quote = match.group(1)\n",
-    "    link = match.group(2)\n",
-    "    new_link = f\"../{link}\"\n",
-    "    return f'<a href={quote}{new_link}{quote}>'\n",
-    "\n",
-    "# Replace links in content to be relative to the top directory of the repo\n",
-    "display(Markdown(pattern.sub(replacer, content)))"
+    "Complete the [Getting to Know You survey](https://absalon.instructure.com/courses/91709/assignments/268606) so we can assign your lab section."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Course Requirements\n",
-    "* Familiarity with machine learning (probability theory, linear algebra, classification)\n",
-    "* Knowledge of programming (Python)\n",
-    "* No prior knowledge of natural language processing or linguistics is required\n",
+    "## Where everything lives\n",
     "\n",
-    "Relevant machine learning competencies can be obtained through one of the following courses: \n",
-    "* [NDAK22000U Machine Learning A (MLA)](https://kurser.ku.dk/course/ndak22000u) and/or [NDAK22001U Machine Learning B (MLB)](https://kurser.ku.dk/course/ndak22001u)\n",
-    "* [NDAK16003U Introduction to Data Science (IDS)](https://kurser.ku.dk/course/ndak16003u)\n",
-    "* [NDAB23000U Grundlæggende Data Science (GDS)](https://kurser.ku.dk/course/NDAB23000U)\n",
-    "* [Machine Learning, Coursera](https://www.coursera.org/learn/machine-learning)\n",
+    "| Place | Use it for |\n",
+    "|---|---|\n",
+    "| [Course repository](https://github.com/coastalcph/nlp-course) | Weekly schedule, readings, slides and lab notebooks |\n",
+    "| [Absalon](https://absalon.ku.dk/courses/91709) | Announcements, discussion and project information |\n",
+    "| Google Colab | Running the lab notebooks; introduced in the first TA session |\n",
+    "| Digital Exam | Final project submission |\n",
     "\n",
-    "See also the [course description](https://kurser.ku.dk/course/ndak18000u)."
+    "The repository changes during the course: check it before each lecture and lab."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### About You: previously taken courses related to NLP?\n",
+    "## What you need\n",
     "\n",
-    "<img src=\"../img/survey_q1.png\">"
+    "- Familiarity with classification, probability and linear algebra\n",
+    "- Enough Python to read, modify and debug short programs\n",
+    "- No prior NLP or linguistics course\n",
+    "- A laptop for short lecture activities and all TA sessions\n",
+    "- The listed reading before each lecture\n",
+    "\n",
+    "The first TA session covers the Colab workflow; it is not a second Python course."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### About You: previously taken courses in Machine Learning?\n",
-    "\n",
-    "<center>\n",
-    "<img src=\"../img/survey_q2.png\">\n",
-    "</center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### About You: experience with using neural network software libraries?\n",
-    "\n",
-    "<img src=\"../img/survey_q3.png\">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### About You: degree are you enrolled in\n",
-    "\n",
-    "<center>\n",
-    "<img src=\"../img/survey_q4.png\">\n",
-    "</center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### About You: what you want to get out of this course\n",
-    "\n",
-    "<img src=\"../img/survey_q5.png\">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### About You: what you want to get out of the lab sessions\n",
-    "\n",
-    "<img src=\"../img/survey_q6.png\">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Course Materials\n",
-    "* We will be using the [nlp-course](../overview.ipynb) repository \n",
-    "* Contains **interactive** [jupyter](http://jupyter.org/) notebooks and slides\n",
-    "    * View statically [here](https://nbviewer.jupyter.org/github/coastalcph/nlp-course/blob/master/overview.ipynb)\n",
-    "    * Use interactively via install, see [github repo](https://github.com/coastalcph/nlp-course) instructions  \n",
-    "* Recordings of 2020 lectures are available on [Absalon](https://absalon.instructure.com/courses/91709/external_tools/14563)\n",
-    "* References to other material are given in context\n",
-    "* This is work in progress.\n",
-    "    * [Previous iterations of the course at DIKU](https://github.com/copenlu/stat-nlp-book)\n",
-    "    * Use `git pull` regularly for updates\n",
-    "    * *Watch* for updates\n",
-    "    * Please contribute by adding issues on github when you see errors\n",
-    "* For assignment hand-in, announcements, discussion forum, check [Absalon](https://absalon.ku.dk/courses/91709)"
+    "## Who is in the room?\n",
+    "\n",
+    "The 2026 survey gives us three useful signals:\n",
+    "\n",
+    "- most respondents are new to NLP;\n",
+    "- machine-learning experience is common, but experience with neural libraries varies;\n",
+    "- students want concrete tutorials, time for project work and access to the TAs for questions.\n",
+    "\n",
+    "We will use examples before abstractions and connect labs directly to the project."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Teaching Methods\n",
-    "* Lectures\n",
-    "* Hands-on lab (TA) sessions\n",
-    "* Group project\n",
-    "* Occasional small exercises during lectures, so bring your laptop\n",
-    "* Background material to read before each lecture"
+    "## The project at a glance\n",
+    "\n",
+    "- Released **2 September**; due **30 October at 17:00**\n",
+    "- Groups of one to three students\n",
+    "- One joint report plus runnable code\n",
+    "- State each member's contribution clearly; grades are individual\n",
+    "- Optional weekly feedback submissions in Weeks 36–41\n",
+    "- Full requirements and evaluation criteria are in the assignment\n",
+    "\n",
+    "We cannot guarantee answers to project questions after **29 October at 15:00**."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Assessment\n",
+    "## Form your project group this week\n",
     "\n",
-    "* **[Group project](https://absalon.instructure.com/courses/91709/assignments/268604)**, can be completed in a group of up to 3 students\n",
-    "    * Group project, can be completed in a group of up to 3 students\n",
-    "    * Released 2 September, hand-in 30 October 17:00\n",
-    "    * Joint report, contribution of each student should be stated clearly\n",
-    "    * Code to be uploaded as attachment\n",
-    "    * Individual grade for each group member, based on the quality and quantity of their contributions\n",
-    "    * Submission via Digital Exam\n",
-    "    * Consists of several parts tied to weekly lecture topics\n",
-    "    * We cannot guarantee responses to queries about the project after 29 October 15:00"
+    "- Join a group within your assigned **Monday or Friday lab section**\n",
+    "- Groups should not mix the two lab sections\n",
+    "- Self-sign-up closes **Wednesday 2 September at 23:59**\n",
+    "- Use the first TA session to resolve group questions\n",
+    "\n",
+    "Group size affects the required extensions and report limit; read the assignment before committing."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Assessment Methods\n",
-    "\n",
-    "* **Group project**, can be completed in a group of up to 3 students\n",
-    "    * Finding a group: \n",
-    "       * Deadline for group forming: **8 September 17:00**\n",
-    "       * We offer to help you find a group -- fill in the [Getting to Know You survey](https://absalon.instructure.com/courses/91709/assignments/268606) by the end of *first lecture day,* **1 September 17:00**\n",
-    "       * If you choose this option, you will be informed of your assigned group on **4 September**\n",
-    "       * You can still change groups afterwards by asking other students to swap groups (it's your responsibility to arrange this)\n",
-    "       * Otherwise, we assume you will find a group by yourself in the first course week, e.g. by coordinating with other students in the lab session"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Late Hand-In\n",
-    "\n",
-    "* Late hand-ins **cannot be accepted**\n",
-    "* Exceptions can be made in rare cases, e.g. due to illness with doctor's notice\n",
-    "    * Get in touch with course organizer at least one working day in advance"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Project Report Submission for Feedback\n",
-    "Optional weekly submission dealdines on Absalon: weeks 36-41.\n",
-    "    \n",
-    "Informal feedback, no grading.\n",
-    "\n",
-    "Highly recommended to make sure you're on track and have the right format etc."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Plagiarism\n",
-    "\n",
-    "* Don't do it\n",
-    "* Don't enable it\n",
-    "* Check [rules and consequences](https://student-ambassador.ku.dk/rights/avoid-plagiarism/) if unclear"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### GenAI Policy\n",
-    "\n",
-    "See [UCPH guidelines](https://kunet.ku.dk/work-areas/teaching/digital-learning/chatgpt-and-ai/guidelines-and-rules-for-chatgpt/Pages/default.aspx).\n",
-    "\n",
-    "As per the [course description](https://kurser.ku.dk/course/ndak18000u), all aids allowed.\n",
-    "\n",
-    "Attach a [declaration of academic use of generative AI](https://kunet.ku.dk/work-areas/teaching/digital-learning/chatgpt-and-ai/new-rules-and-principles-from-september-2025/template-for-declaration/Pages/default.aspx) to your project submission."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Python\n",
-    "\n",
-    "* Lectures, lab exercises and assignments focus on **Python**\n",
-    "* Python is a leading language for data science, machine learning etc., with many relevant libraries\n",
-    "* We expect you to know Python, or be willing to learn it **on your own**\n",
-    "* Labs and assignments focus on development within [jupyter notebooks](http://jupyter.org/)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Lab Sessions\n",
+    "## Submission, integrity and GenAI\n",
     "\n",
-    "* Some lab sessions are tutorial-style (to introduce you to practical aspects of the course)\n",
-    "* Other lab sessions are open-topic. You can use them as an opportunity to:\n",
-    "   * ask the TAs clarifying questions about the lectures and/or project\n",
-    "   * ask the TAs for informal feedback on your project so far\n",
-    "   * work on your project with your group"
+    "- Late submissions cannot be accepted except in documented exceptional circumstances\n",
+    "- Plagiarism and enabling plagiarism are academic misconduct\n",
+    "- Generative AI tools are allowed under the [course description](https://kurser.ku.dk/course/ndak18000u)\n",
+    "- Follow the assignment's declaration and interaction-log requirements\n",
+    "\n",
+    "If illness may affect submission, contact the course organizer at least one working day in advance."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "### Discussion Forum\n",
+    "## Questions and support\n",
     "\n",
-    "* Our Absalon page has a [**discussion forum**](https://absalon.instructure.com/courses/91709/discussion_topics).\n",
-    "* Please post questions there (instead of sending private emails) \n",
-    "* We give low priority to **questions already answered** in previous lectures, tutorials and posts, \n",
-    "    * and to **pure programming related issues**\n",
-    "* We expect you to **search online** for answers to your questions before you contact us.\n",
-    "* You are highly encouraged to participate and **help each other** on the forum. \n",
-    "* The teaching team will check the discussion forum regularly **within normal working hours**\n",
-    "    * do not expect answers late in the evenings and on weekends\n",
-    "    * **start working on your project early**\n",
-    "    * come to the lab sessions and ask questions there"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### DIKU NLP\n",
+    "**TA sessions:** practical exercises, project work, feedback and programming questions\n",
     "\n",
-    "* Part of the AI Research Section, UCPH Computer Science Department\n",
-    "* Faculty members: Isabelle Augenstein, Pepa Atanasova, Daniel Hershcovich, Desmond Elliott, Anders Søgaard\n",
-    "* Official webpage: https://di.ku.dk/english/research/ai/\n",
-    "* List of group members: https://www.copenlu.com/ ; http://coastalcph.github.io/; https://lampgroup.github.io/\n",
-    "* Always looking for strong MSc students\n",
-    "* PhD positions available dependent on funding"
+    "**Absalon forum:** questions whose answers may help the whole class\n",
+    "\n",
+    "Before posting, check the course material and earlier discussions. Include the relevant code, error and what you already tried. The teaching team checks the forum during normal working hours."
    ]
   }
  ],

--- a/chapters/intro_short.ipynb
+++ b/chapters/intro_short.ipynb
@@ -67,408 +67,131 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "# Introduction"
+    "# Introduction to NLP\n",
+    "\n",
+    "### Tasks, data, models and evaluation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "## What is NLP?\n",
+    "## Learning objectives\n",
     "\n",
-    "* Building computer systems that **understand** and **generate** natural languages.\n",
-    "* Deep understanding of **broad** language\n",
-    "    * not just string processing or keyword matching\n",
-    "    "
+    "By the end of today's lecture, you should be able to:\n",
+    "\n",
+    "- define an NLP task through its inputs, outputs, data and evaluation;\n",
+    "- explain why tokenisation is a modelling choice;\n",
+    "- compare whitespace, regex/library and subword tokenisers;\n",
+    "- trace BPE merges and interpret a simple text classifier."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "Can you think of NLP Applications?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Chatbots\n",
+    "## NLP maps language to useful outputs\n",
     "\n",
-    "![chatgpt_nlp_applications](../img/chatgpt_nlp_applications.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Speech Recognition?\n",
+    "| Output | Example task |\n",
+    "|---|---|\n",
+    "| A category or score | sentiment, topic, answerability |\n",
+    "| A label for each unit | part-of-speech tagging, named entities |\n",
+    "| A span or structure | information extraction, parsing, question answering |\n",
+    "| Text in another form | translation, summarisation, dialogue |\n",
+    "| A probability over text | language modelling |\n",
     "\n",
-    "Speech Recognition is a challenging application, but is usually not considered NLP. We will not cover this topic here."
+    "The task determines what counts as a correct output."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "![beach](../img/wreckanicebeach.png)\n",
-    "\n",
-    "recognise speech vs. wreck a nice beach\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Sentiment Analysis\n",
-    "\n",
-    "![sent](../img/sentiment_0.png)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Machine Translation\n",
-    "\n",
-    "![mt](mt_figures/avocado.png)\n",
-    "\n",
-    "http://translate.google.com/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Information Extraction\n",
-    "![ie1](../img/ie1.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Information Extraction\n",
-    "![ie2](../img/ie2.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Generation\n",
-    "![gen](../img/shirtless2.jpeg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Generation\n",
-    "![gen](../img/shirtless.jpeg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Reading Comprehension\n",
-    "\n",
-    "<center>\n",
-    "<img src=\"../img/tydiqa_graupel.png\" width=\"600\"/>\n",
-    "</center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Personal Assistants\n",
-    "<table><tr>\n",
-    "<td> <img src=\"../img/siri-hates-eggs-photo-u1.jpg\" alt=\"Siri1\" style=\"width: 500px;\"/> </td>\n",
-    "<td> <img src=\"../img/GoogleAssistantFail_07.jpg\" alt=\"Siri2\" style=\"width: 450px;\"/> </td>\n",
-    "</tr></table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "<center><img src=\"../img/quiz_time.png\"></center>\n",
+    "## One text can define several tasks\n",
     "\n",
-    "What is difficult about NLP?\n",
+    "> The battery lasts all day, but the camera is disappointing.\n",
     "\n",
-    "Discuss and enter your answers here:\n",
+    "- **Classification:** is the review positive, negative or mixed?\n",
+    "- **Sequence labelling:** which tokens mention product aspects?\n",
+    "- **Information extraction:** battery life → positive; camera → negative\n",
+    "- **Question answering:** what is disappointing? → the camera\n",
+    "- **Generation:** produce a one-sentence summary\n",
     "\n",
-    "# [tinyurl.com/diku-nlp-q1](https://tinyurl.com/diku-nlp-q1)\n",
-    "\n",
-    "([Responses](https://docs.google.com/forms/d/121VI1BeO1TWuWXnAeQbHcBdMazQ3rPivoko29YyrZz4/edit#responses))"
+    "The same language does not imply the same supervision or metric."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Ambiguity Everywhere\n",
-    "\n",
-    "* Fed <b>raises</b> interest rates 0.5% in effort to control inflation\n",
-    "* Fed raises <b>interest</b> rates 0.5% in effort to control inflation\n",
-    "* Fed raises interest <b>rates</b> 0.5% in effort to control inflation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Ambiguity Everywhere\n",
-    "\n",
-    "\"Jane ate spaghetti with a **silver spoon**.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Do you mean..."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Jane used a silver spoon to eat spaghetti? (**cutlery**)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Jane had spaghetti and a silver spoon? (**part**)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Jane exhibited a silver spoon while eating spaghetti? (**manner**)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "Jane ate spaghetti in the presence of a silver spoon? (**company**)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### Ambiguity on different linguistic levels\n",
-    "\n",
-    "<img src=\"../img/nlp_pyramid.png\" style=\"float:left;\" width=45%></img>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "## Core NLP Tasks\n",
-    "* Tokenisation, Segmentation\n",
-    "* Part of Speech Tagging\n",
-    "* Language Modelling\n",
-    "* Machine Translation\n",
-    "* Syntactic and Semantic Parsing\n",
-    "* Document Classification\n",
-    "* Information Extraction\n",
-    "* Question Answering"
+    "## A model is one component of an NLP system\n",
+    "\n",
+    "1. **Task:** what input produces what output?\n",
+    "2. **Data:** who wrote and annotated the examples, and for which setting?\n",
+    "3. **Representation:** characters, words, subwords or learned vectors?\n",
+    "4. **Model:** rules, linear classifier, neural network or language model?\n",
+    "5. **Evaluation:** which errors matter, and to whom?\n",
+    "\n",
+    "A stronger model cannot repair a badly defined task or an invalid evaluation."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "slide"
     }
    },
    "source": [
-    "## Core NLP Methods\n",
+    "## Language variation makes errors systematic\n",
     "\n",
-    "* Structured Prediction \n",
-    "* Preprocessing\n",
-    "* Generative Learning\n",
-    "* Discriminative Learning\n",
-    "* Weak Supervision\n",
-    "* Representation and Deep Learning"
+    "- **Ambiguity:** “I saw her duck” permits different structures and meanings\n",
+    "- **Context:** the intended answer may depend on earlier turns or shared knowledge\n",
+    "- **Domain and register:** clinical notes, social media and news follow different conventions\n",
+    "- **Language and culture:** categories and assumptions do not transfer uniformly\n",
+    "- **Use:** benchmark accuracy may not reflect whether a system helps its users\n",
+    "\n",
+    "NLP therefore combines modelling with careful choices about data and evaluation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## We study tasks before increasingly shared models\n",
+    "\n",
+    "- **Weeks 36–38:** tokenisation, classification, sequence labelling, language models and embeddings\n",
+    "- **Weeks 39–40:** recurrent networks, attention and Transformers\n",
+    "- **Week 41:** information extraction and question answering\n",
+    "- **Week 43:** multilingual, multicultural and sociotechnical perspectives\n",
+    "- **Week 44:** parsing and machine translation\n",
+    "\n",
+    "We start with the smallest decision in the pipeline: **what counts as a token?**"
    ]
   }
  ],

--- a/chapters/tokenization_slides.ipynb
+++ b/chapters/tokenization_slides.ipynb
@@ -66,11 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "slideshow": {
      "slide_type": "skip"
     }
@@ -80,552 +77,369 @@
     "%%capture\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "%cd ..\n",
-    "import statnlpbook.tokenization as tok"
+    "%cd .."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "# Tokenisation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "* Identify the **meaningful units** in a string of characters: for example, **words**.\n",
+    "# Tokenisation\n",
     "\n",
-    "![nospaces](../img/nospaces.jpg)"
+    "### Choosing the units a model will process"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "In Python you can tokenise text via `split`:"
+    "## Tokenisation is a modelling decision\n",
+    "\n",
+    "The string\n",
+    "\n",
+    "> We can't re-use a word-level model in 北京.\n",
+    "\n",
+    "could be represented as:\n",
+    "\n",
+    "- words and punctuation;\n",
+    "- language-specific segments;\n",
+    "- characters or bytes;\n",
+    "- learned subwords.\n",
+    "\n",
+    "The choice changes sequence length, vocabulary size and what the model can reuse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Whitespace is a useful baseline\n",
+    "\n",
+    "It is fast and transparent—but spaces do not consistently mark linguistic units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['Mr.',\n",
-       " 'Bob',\n",
-       " 'Dobolina',\n",
-       " 'is',\n",
-       " \"thinkin'\",\n",
-       " 'of',\n",
-       " 'a',\n",
-       " 'master',\n",
-       " 'plan.\\nWhy',\n",
-       " \"doesn't\",\n",
-       " 'he',\n",
-       " 'quit?']"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Mr.', 'Bob', 'Dobolina', 'is', \"thinkin'\", 'of', 'a', 'master', 'plan.', 'Why', \"doesn't\", 'he', 'quit?']"
+     ]
     }
    ],
    "source": [
-    "text = \"\"\"Mr. Bob Dobolina is thinkin' of a master plan.\n",
-    "Why doesn't he quit?\"\"\"\n",
-    "text.split(\" \")"
+    "text = \"Mr. Bob Dobolina is thinkin' of a master plan. Why doesn't he quit?\"\n",
+    "print(text.split())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "slide"
     }
    },
    "source": [
-    "What is wrong with this?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "In Python you can also tokenise using **patterns** at which to split tokens:\n",
-    "### Regular Expressions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "A **regular expression** is a compact definition of a **set** of (character) sequences (strings).\n",
+    "## A short regex can encode explicit conventions\n",
     "\n",
-    "Examples:\n",
-    "* `Mr.`: all strings containing `Mr` followed by any single character\n",
-    "* `Mr\\.`: only the string `Mr.`\n",
-    "* <code>&nbsp;</code>`|\\n|!!!`: only the strings <code>&nbsp;</code> (space), `\\n` and `!!!`\n",
-    "* `[abc]`: only the characters `a`, `b` and `c`\n",
-    "* `\\s`: all whitespace characters\n",
-    "* `1+`: all sequences of at least one `1`\n",
-    "* `\\w+`: all sequences of alphanumeric characters and `_`\n"
+    "- Keep **Mr.** together\n",
+    "- Keep apostrophes inside words\n",
+    "- Separate other punctuation\n",
+    "\n",
+    "Regex is useful when the rules are known and local. It becomes brittle when languages and domains require many exceptions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "slideshow": {
-     "slide_type": "subslide"
+     "slide_type": "fragment"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['Mr.',\n",
-       " 'Bob',\n",
-       " 'Dobolina',\n",
-       " 'is',\n",
-       " \"thinkin'\",\n",
-       " 'of',\n",
-       " 'a',\n",
-       " 'master',\n",
-       " 'plan.',\n",
-       " 'Why',\n",
-       " \"doesn't\",\n",
-       " 'he',\n",
-       " 'quit?']"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Mr.', 'Bob', 'Dobolina', 'is', \"thinkin'\", 'of', 'a', 'master', 'plan', '.', 'Why', \"doesn't\", 'he', 'quit', '?']"
+     ]
     }
    ],
    "source": [
     "import re\n",
-    "re.compile('\\s').split(text)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Problems:\n",
-    "* Bad treatment of punctuation.  \n",
-    "* Easier to **define a token** than a gap. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Let us use `findall` instead:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Mr',\n",
-       " '.',\n",
-       " 'Bob',\n",
-       " 'Dobolina',\n",
-       " 'is',\n",
-       " 'thinkin',\n",
-       " 'of',\n",
-       " 'a',\n",
-       " 'master',\n",
-       " 'plan',\n",
-       " '.',\n",
-       " 'Why',\n",
-       " 'doesn',\n",
-       " 't',\n",
-       " 'he',\n",
-       " 'quit',\n",
-       " '?']"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "re.compile('\\w+|[.?]').findall(text)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Problems:\n",
-    "* `Mr.` and `doesn't` are split into two tokens each.\n",
-    "* Lost an apostrophe (`thinkin'`).\n",
     "\n",
-    "Both are fixed below ..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Mr.',\n",
-       " 'Bob',\n",
-       " 'Dobolina',\n",
-       " 'is',\n",
-       " \"thinkin'\",\n",
-       " 'of',\n",
-       " 'a',\n",
-       " 'master',\n",
-       " 'plan',\n",
-       " '.',\n",
-       " 'Why',\n",
-       " \"doesn't\",\n",
-       " 'he',\n",
-       " 'quit',\n",
-       " '?']"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "re.compile('Mr\\.|[\\w\\']+|[.?]').findall(text)"
+    "pattern = r\"Mr\\.|\\w+(?:'\\w+)*'?|[^\\w\\s]\"\n",
+    "print(re.findall(pattern, text))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "## Learning to Tokenise?\n",
-    "* For English, simple pattern matching is often sufficient.\n",
-    "* In some languages (e.g., Japanese), words are not separated by whitespace.\n",
-    "* In some languages (e.g., Vietnamese), whitespace does not indicate word boundary.\n"
+    "## NLTK provides reusable tokenisation conventions\n",
+    "\n",
+    "Use a tokenizer designed for the text you have:\n",
+    "\n",
+    "- <code>word_tokenize</code> / <code>TreebankWordTokenizer</code> for conventional English text\n",
+    "- <code>TweetTokenizer</code> for handles, hashtags and emoticons\n",
+    "- <code>sent_tokenize</code> for sentence segmentation\n",
+    "\n",
+    "Library tokenizers are strong baselines, not universal ground truth."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Mr.', 'Bob', 'Dobolina', 'is', 'thinkin', \"'\", 'of', 'a', 'master', 'plan.', 'Why', 'does', \"n't\", 'he', 'quit', '?']\n",
+      "['@diku', 'Great', 'course', ':-)', '#NLP']"
+     ]
+    }
+   ],
+   "source": [
+    "from nltk.tokenize import TreebankWordTokenizer, TweetTokenizer\n",
+    "\n",
+    "print(TreebankWordTokenizer().tokenize(text))\n",
+    "print(TweetTokenizer().tokenize(\"@diku Great course :-) #NLP\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## No tokenizer is language- or domain-neutral\n",
+    "\n",
+    "| Text | Boundary problem |\n",
+    "|---|---|\n",
+    "| 今日もしないといけない。 | Japanese normally has no spaces between words |\n",
+    "| thuế thu nhập cá nhân | Vietnamese spaces can separate syllables rather than words |\n",
+    "| (TPGS)-cisplatin | Biomedical punctuation may carry domain-specific structure |\n",
+    "| New York-based | Several reasonable tokenisations serve different tasks |\n",
+    "\n",
+    "When fixed rules stop scaling, we can learn reusable units from data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Subword tokenisation\n",
+    "\n",
+    "### A fixed vocabulary between words and characters\n",
+    "\n",
+    "| Units | Vocabulary | Sequence length | Unseen strings |\n",
+    "|---|---:|---:|---|\n",
+    "| Words | large | short | problematic |\n",
+    "| Characters/bytes | small | long | always representable |\n",
+    "| Subwords | medium | medium | decomposed into known pieces |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## BPE repeatedly merges frequent adjacent symbols\n",
+    "\n",
+    "Start with characters plus an end-of-word marker:\n",
+    "\n",
+    "| Training word | Frequency | Initial symbols |\n",
+    "|---|---:|---|\n",
+    "| low | 5 | l · o · w · &lt;/w&gt; |\n",
+    "| lower | 2 | l · o · w · e · r · &lt;/w&gt; |\n",
+    "| newest | 6 | n · e · w · e · s · t · &lt;/w&gt; |\n",
+    "| widest | 3 | w · i · d · e · s · t · &lt;/w&gt; |\n",
+    "\n",
+    "Count pairs **with corpus frequencies**, merge the most frequent pair, and repeat."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Pair counts make the first merge concrete\n",
+    "\n",
+    "In the weighted corpus:\n",
+    "\n",
+    "- <code>e + s</code>: 6 occurrences in *newest* + 3 in *widest* = **9**\n",
+    "- <code>s + t</code>: 6 + 3 = **9**\n",
+    "- <code>l + o</code>: 5 in *low* + 2 in *lower* = **7**\n",
+    "\n",
+    "Ties need a deterministic rule. Here we choose the alphabetically first pair."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Count weighted adjacent pairs in Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(('e', 's'), 9), (('s', 't'), 9), (('t', '</w>'), 9), (('w', 'e'), 8), (('l', 'o'), 7)]"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "corpus = {\"low\": 5, \"lower\": 2, \"newest\": 6, \"widest\": 3}\n",
+    "vocab = {tuple(word) + (\"</w>\",): freq for word, freq in corpus.items()}\n",
+    "\n",
+    "def pair_counts(vocabulary):\n",
+    "    counts = Counter()\n",
+    "    for symbols, frequency in vocabulary.items():\n",
+    "        for pair in zip(symbols, symbols[1:]):\n",
+    "            counts[pair] += frequency\n",
+    "    return counts\n",
+    "\n",
+    "print(pair_counts(vocab).most_common(5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Replace every occurrence of the selected pair"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "outputs": [],
    "source": [
-    "jap = \"今日もしないといけない。\"\n",
-    "viet = \"thuế  thu nhập cá nhân\""
+    "def merge_pair(vocabulary, pair):\n",
+    "    updated = {}\n",
+    "    for symbols, frequency in vocabulary.items():\n",
+    "        merged, i = [], 0\n",
+    "        while i < len(symbols):\n",
+    "            if i + 1 < len(symbols) and tuple(symbols[i:i + 2]) == pair:\n",
+    "                merged.append(\"\".join(pair)); i += 2\n",
+    "            else:\n",
+    "                merged.append(symbols[i]); i += 1\n",
+    "        key = tuple(merged)\n",
+    "        updated[key] = updated.get(key, 0) + frequency\n",
+    "    return updated"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "subslide"
     }
    },
    "source": [
-    "Try lexicon-based tokenisation ..."
+    "## Repeat counting and merging"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['今日', 'もし', 'と', 'いけない']"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: ('e', 's')  count=9\n",
+      "2: ('es', 't')  count=9\n",
+      "3: ('est', '</w>')  count=9\n",
+      "4: ('l', 'o')  count=7\n",
+      "5: ('lo', 'w')  count=7"
+     ]
     }
    ],
    "source": [
-    "re.compile('もし|今日|も|しない|と|いけない').findall(jap)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['thuế  thu nhập', 'cá nhân']"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "re.compile('thuế  thu nhập|cá nhân').findall(viet)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Equally complex for certain English domains (e.g., biomedical text)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "bio = \"\"\"We developed a nanocarrier system of herceptin-conjugated nanoparticles\n",
-    "of d-alpha-tocopheryl-co-poly(ethylene glycol) 1000 succinate (TPGS)-cisplatin\n",
-    "prodrug ...\"\"\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "source": [
-    "* d-alpha-tocopheryl-co-poly is **one** token\n",
-    "* (TPGS)-cisplatin are **five**: \n",
-    "  * ( \n",
-    "  * TPGS \n",
-    "  * ) \n",
-    "  * - \n",
-    "  * cisplatin "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['We',\n",
-       " 'developed',\n",
-       " 'a',\n",
-       " 'nanocarrier',\n",
-       " 'system',\n",
-       " 'of',\n",
-       " 'herceptin-conjugated',\n",
-       " 'nanoparticles',\n",
-       " 'of',\n",
-       " 'd-alpha-tocopheryl-co-poly(ethylene',\n",
-       " 'glycol)',\n",
-       " '1000',\n",
-       " 'succinate',\n",
-       " '(TPGS)-cisplatin',\n",
-       " 'prodrug']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "re.compile('\\s').split(bio)[:15]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['New', 'York-based', 'companies']"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "re.compile('\\s').split(\"New York-based companies\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "Solution: Treat tokenisation as a **statistical problem**."
+    "def learn_bpe(vocabulary, number_of_merges):\n",
+    "    merges = []\n",
+    "    for step in range(number_of_merges):\n",
+    "        counts = pair_counts(vocabulary)\n",
+    "        best = min(counts, key=lambda pair: (-counts[pair], pair))\n",
+    "        print(f\"{step + 1}: {best}  count={counts[best]}\")\n",
+    "        merges.append(best)\n",
+    "        vocabulary = merge_pair(vocabulary, best)\n",
+    "    return merges\n",
+    "\n",
+    "merges = learn_bpe(vocab, 5)"
    ]
   },
   {
@@ -636,104 +450,14 @@
     }
    },
    "source": [
-    "# Subword Tokenisation\n",
+    "## Encoding replays the learned merge order\n",
     "\n",
-    "Learn from data what is the best way to break down strings to tokens.\n",
-    "\n",
-    "- **Why Subword Tokenization?**\n",
-    "  - Efficient handling of Out-of-Vocabulary (OOV) words.\n",
-    "  - Capture meaningful subword information.\n",
-    "- **Popular Algorithms**: \n",
-    "  - WordPiece\n",
-    "  - Byte Pair Encoding (BPE)\n",
-    "  - Unigram (SentencePiece)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## WordPiece\n",
-    "- **Used In**: BERT, DistillBERT\n",
-    "- **Origin**: Developed by Google for speech recognition and later adapted for text.\n",
-    "- **How it Works**: \n",
-    "  1. Initialize vocabulary with characters and special tokens.\n",
-    "  2. Merge subwords iteratively based on scoring criteria to form the new vocabulary."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "### WordPiece Examples\n",
-    "- **English**: \"hugging\": \n",
-    "  - Initial: (\"h\", \"u\", \"g\", \"g\", \"i\", \"n\", \"g\")\n",
-    "  - After training: (\"hug\", \"##ging\")\n",
-    "- **Danish**: \"hygge\"\n",
-    "  - Initial: (\"h\", \"y\", \"g\", \"g\", \"e\")\n",
-    "  - After training: (\"hy\", \"##gge\")\n",
-    "- **Japanese**: \"こんにちは\" \n",
-    "  - Initial: (\"こ\", \"ん\", \"に\", \"ち\", \"は\")\n",
-    "  - After training: (\"こん\", \"##に\", \"##ち\", \"##は\")\n",
-    "- **Vietnamese**: \"xin chào\"\n",
-    "  - Initial: (\"x\", \"i\", \"n\", \" \", \"c\", \"h\", \"à\", \"o\")\n",
-    "  - After training: (\"x\", \"##in\", \" \", \"##ch\", \"##à\", \"##o\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Byte Pair Encoding (BPE)\n",
-    "- **Used In**: GPT, RoBERTa\n",
-    "- **Origin**: Initially developed for data compression.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "## Unigram Algorithm in SentencePiece\n",
-    "- **Used In**: ALBERT, T5, mBART, Big Bird, XLNet\n",
-    "- **Origin**: Developed by Google for machine translation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "# Sentence Segmentation\n",
-    "\n",
-    "* Many NLP tools work sentence-by-sentence. \n",
-    "* Often trivial after tokenisation: split sentences at sentence-ending punctuation tokens."
+    "Do **not** learn new merges from the test word. Start from its characters and apply the training merges in order."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -741,96 +465,120 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\"Mr. Bob Dobolina is thinkin' of a master plan.\\nWhy doesn't he quit?\""
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lowest -> ['low', 'est']\n",
+      " newer -> ['n', 'e', 'w', 'e', 'r']\n",
+      "widest -> ['w', 'i', 'd', 'est']"
+     ]
     }
    ],
    "source": [
-    "text"
+    "def encode_bpe(word, learned_merges):\n",
+    "    symbols = tuple(word) + (\"</w>\",)\n",
+    "    for pair in learned_merges:\n",
+    "        symbols = next(iter(merge_pair({symbols: 1}, pair)))\n",
+    "    return [s.replace(\"</w>\", \"\") for s in symbols if s != \"</w>\"]\n",
+    "\n",
+    "for word in [\"lowest\", \"newer\", \"widest\"]:\n",
+    "    print(f\"{word:>6} -> {encode_bpe(word, merges)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Related algorithms make different vocabulary choices\n",
+    "\n",
+    "| Method | Training idea | Familiar example |\n",
+    "|---|---|---|\n",
+    "| **BPE** | repeatedly merge frequent adjacent symbols | GPT-2 and RoBERTa use byte-level BPE |\n",
+    "| **WordPiece** | select pieces with a likelihood-inspired score | BERT; continuation pieces such as <code>##ing</code> |\n",
+    "| **Unigram** | start large and remove pieces that least improve the objective | T5 via SentencePiece |\n",
+    "\n",
+    "**SentencePiece is a toolkit** that can train BPE or unigram models and represents whitespace explicitly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Sentence segmentation\n",
+    "\n",
+    "Sentence boundaries are usually predicted rather than defined by one punctuation rule."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[['Mr.',\n",
-       "  'Bob',\n",
-       "  'Dobolina',\n",
-       "  'is',\n",
-       "  \"thinkin'\",\n",
-       "  'of',\n",
-       "  'a',\n",
-       "  'master',\n",
-       "  'plan',\n",
-       "  '.'],\n",
-       " ['Why', \"doesn't\", 'he', 'quit', '?']]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Mr. Bob arrived at 9.', 'It rained.', 'Really?']"
+     ]
     }
    ],
    "source": [
-    "tokens = re.compile('Mr.|[\\w\\']+|[.?]').findall(text)\n",
-    "# try different regular expressions\n",
-    "tok.sentence_segment(re.compile('\\.'), tokens)"
+    "import nltk\n",
+    "from nltk.tokenize import sent_tokenize\n",
+    "\n",
+    "sample = \"Mr. Bob arrived at 9. It rained. Really?\"\n",
+    "try:\n",
+    "    sentences = sent_tokenize(sample)\n",
+    "except LookupError:\n",
+    "    nltk.download(\"punkt_tab\", quiet=True)\n",
+    "    sentences = sent_tokenize(sample)\n",
+    "print(sentences)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "<center><img src=\"../img/quiz_time.png\"></center>\n",
-    "\n",
-    "What are the challenges in sentence splitting? \n",
-    "\n",
-    "Discuss and enter your answer(s) here:\n",
-    "\n",
-    "# [tinyurl.com/diku-nlp-q2](https://tinyurl.com/diku-nlp-q2)\n",
-    "\n",
-    "([Responses](https://docs.google.com/forms/d/1WANt_ndHZhGkOwPu1klR4HmGAUH1QL9W4AAkNwU6Ulg/edit))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "# Background Reading\n",
+    "## Tokenisation checklist\n",
     "\n",
-    "* Jurafsky & Martin, [Speech and Language Processing, Chapter 2: Words and Tokens](https://web.stanford.edu/~jurafsky/slp3/2.pdf): Chapter 2, Regular Expressions, Text Normalization, Edit Distance.\n",
-    "* Hugging Face's excellent NLP course: [Tokenizers](https://huggingface.co/learn/nlp-course/chapter6/1)"
+    "- Start with a transparent baseline: whitespace, regex or an NLTK tokenizer\n",
+    "- Match tokenisation to language, domain and downstream labels\n",
+    "- For learned subwords, inspect the training objective and actual outputs\n",
+    "- Preserve offsets when tokens must map back to the original text\n",
+    "- Evaluate downstream errors—not tokenisation in isolation\n",
+    "\n",
+    "Next: represent a document and predict its class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# Background reading\n",
+    "\n",
+    "- Jurafsky & Martin, [Chapter 2: Regular Expressions, Text Normalization, Edit Distance](https://web.stanford.edu/~jurafsky/slp3/2.pdf)\n",
+    "- NLTK, [Tokenization API](https://www.nltk.org/api/nltk.tokenize.html)\n",
+    "- Hugging Face NLP Course, [Tokenizers](https://huggingface.co/learn/nlp-course/chapter6/1)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

- reduce the logistics, NLP introduction and tokenisation sequence from 84 to 34 slide states
- consolidate repeated setup, Python, materials, assessment and support information into ten logistics slides
- replace the dated application gallery with a task-first introduction organised around task, data, representation, model and evaluation
- retain one concrete example across classification, sequence labelling, extraction, QA and generation
- reduce regex to one transparent baseline and add NLTK Treebank, tweet and sentence tokenisation
- replace the high-level subword overview with executable BPE pair counting, merging, training and unseen-word encoding
- distinguish BPE, WordPiece, unigram and SentencePiece precisely

The intended pacing is approximately 15 minutes for logistics, 8 minutes for the NLP introduction and 25–30 minutes for tokenisation, leaving the remainder of the 105-minute lecture for text classification and transitions.

## Validation

- validated all three notebooks with `nbformat`
- compiled every Python code cell
- executed the regex, NLTK word/tweet and BPE cells sequentially
- verified the BPE merge trace and unseen-word encodings
- exported all three notebooks successfully with `nbconvert --to slides`
- rendered and inspected all 34 slide states; page count matches slide count with no overflow
- `git diff --check` passes